### PR TITLE
Feature/lsp for web

### DIFF
--- a/lua/PluginConfig/nvim-lspconfig.lua
+++ b/lua/PluginConfig/nvim-lspconfig.lua
@@ -167,6 +167,9 @@ lsp_settings["bashls"] = {}
 -- javascript/typescript
 lsp_settings["tsserver"] = {}
 
+-- html
+lsp_settings["html"] = {}
+
 -- local my_capabilities = lsp.protocol.make_client_capabilities()
 -- my_capabilities.textDocument.completion.completionItem.snippetSupport = true
 local my_capabilities = lsp.protocol.make_client_capabilities()

--- a/lua/PluginConfig/nvim-lspconfig.lua
+++ b/lua/PluginConfig/nvim-lspconfig.lua
@@ -170,6 +170,9 @@ lsp_settings["tsserver"] = {}
 -- html
 lsp_settings["html"] = {}
 
+-- css
+lsp_settings["cssls"] = {}
+
 -- local my_capabilities = lsp.protocol.make_client_capabilities()
 -- my_capabilities.textDocument.completion.completionItem.snippetSupport = true
 local my_capabilities = lsp.protocol.make_client_capabilities()


### PR DESCRIPTION
# English
I have set up lsp servers for the languages essential to developing web applications. Specifically, I enabled lsp servers for HTML and CSS.

# 日本語（ Original ）
Webアプリを作る上で必要な言語に対して、lspサーバーが起動されるようにした。具体的には、htmlとcssに対してlspサーバーが起動されるようにした。