### PR TITLE
bugfix - the settings for autotag was wrong

### DIFF
--- a/lua/PluginConfig/nvim-treesitter.lua
+++ b/lua/PluginConfig/nvim-treesitter.lua
@@ -1,6 +1,6 @@
 local opt = vim.opt
 
-require'nvim-treesitter.configs'.setup {
+require 'nvim-treesitter.configs'.setup {
   -- A list of parser names, or "all"
   ensure_installed = "all",
   highlight = {
@@ -15,9 +15,9 @@ require'nvim-treesitter.configs'.setup {
   indent = {
     enable = true
   },
-  -- autotag = {
-  --   enable = true,
-  -- }
+  autotag = {
+    enable = true,
+  }
   -- pairs = {
   --   enable = false,
   --   disable = {},
@@ -31,4 +31,3 @@ require'nvim-treesitter.configs'.setup {
 
 opt.foldmethod = "expr"
 opt.foldexpr = "nvim_treesitter#foldexpr()"
-

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -15,6 +15,7 @@ local plugin_list = {
     "nvim-treesitter/nvim-treesitter",
     event = 'BufReadPost',
     build = ':TSUpdateSync',
+    dependencies = { 'windwp/nvim-ts-autotag' },
     config = function()
       require("PluginConfig/nvim-treesitter")
     end,
@@ -59,12 +60,12 @@ local plugin_list = {
     'echasnovski/mini.nvim',
     event = 'VeryLazy',
     version = false,
-    config = function ()
+    config = function()
       require("PluginConfig.mini-surround")
     end
   },
   { 'tpope/vim-surround',      event = "InsertEnter" },
-  { 'windwp/nvim-ts-autotag',  event = "InsertEnter" },
+  { 'windwp/nvim-ts-autotag', },
   {
     "windwp/nvim-autopairs",
     event = "InsertEnter",


### PR DESCRIPTION
# English
I fixed the incorrect configuration for using nvim-ts-autotag.

# 日本語（ Original ）
nvim-ts-autotagを利用するための設定が間違っていたので修正した。