### PR TITLE
Modify/surround config

### DIFF
--- a/lua/PluginConfig/mini-surround.lua
+++ b/lua/PluginConfig/mini-surround.lua
@@ -1,4 +1,5 @@
 require('mini.surround').setup({
+  n_lines = 100,
   -- Let the first character is 'c', from "Closure".
   -- When it is 's', I felt it was not user-friendly.
   mappings = {

--- a/lua/PluginConfig/mini-surround.lua
+++ b/lua/PluginConfig/mini-surround.lua
@@ -4,10 +4,10 @@ require('mini.surround').setup({
   mappings = {
     add = 'ca',            -- Add surrounding in Normal and Visual modes
     delete = 'cd',         -- Delete surrounding
-    find = 'cf',           -- Find surrounding (to the right)
-    find_left = 'cF',      -- Find surrounding (to the left)
+    find = 'c<',           -- Find surrounding (to the right)
+    find_left = 'c>',      -- Find surrounding (to the left)
     highlight = 'ch',      -- Highlight surrounding
-    replace = 'cr',        -- Replace surrounding
+    replace = 'cs',        -- Replace surrounding
     update_n_linec = 'cn', -- Update `n_lines`
     update_n_lines = '',
 


### PR DESCRIPTION
# English
1. I made lager the value of n_lines because the default was too small.
2. Additionally, I made the keymaps more user-friendly.

# 日本語（ Original ）
1. デフォルトのn_linesでは少し小さすぎたため、n_linesを大きくした。
2. キーマップをより使いやすくした。