### PR TITLE
bugfix - I made a mistake with the settings for the formatter embedded in lsp

### DIFF
--- a/lua/PluginConfig/nvim-lspconfig.lua
+++ b/lua/PluginConfig/nvim-lspconfig.lua
@@ -57,9 +57,8 @@ local my_on_attach = function(client, bufnr)
   keymap.set('n', 'gr', lsp.buf.references, bufopts)
 
   if client.server_capabilities.documentFormattingProvider then
-    keymap.set( 'n', '<space>f', vim.lsp.buf.format(), {noremap = false, silent = true, buffer = bufnr} )
+    keymap.set('n', '<space>f', function() lsp.buf.format { async = true } end, { noremap = false, silent = true, buffer = bufnr })
   end
-  -- keymap.set('n', '<space>f', function() lsp.buf.format { async = true } end, bufopts)
 
   -- Find the clients capabilities
   local doc_light = client.server_capabilities.documentHighlightProvider


### PR DESCRIPTION
# English
I had incorrectly configured the settings for the formatter embedded in LSP. As a result, the formatter did not run even when I pressed '<space>f'. I've corrected this.

# 日本語（ Original ）
LSPに付属しているフォーマッタの設定を間違えていて、'<space>f'を押しても、フォーマッタが起動しなかったのを修正した。