### PR TITLE
remove - print function displaying redundant message

### DIFF
--- a/lua/PluginConfig/nvim-lspconfig.lua
+++ b/lua/PluginConfig/nvim-lspconfig.lua
@@ -79,7 +79,6 @@ local my_on_attach = function(client, bufnr)
     }
   }
   if client.name == "tsserver" then
-    print(format_keymap["use_formatter"])
     util.add_keymaps(format_keymap["use_formatter"])
   elseif client.server_capabilities.documentFormattingProvider then
     util.add_keymaps(format_keymap["use_lsp"])


### PR DESCRIPTION
デバッグ用のprint出力が残っていたので、それを削除した。