### PR TITLE
Support/rename of ddc source lsp

### DIFF
--- a/lua/PluginConfig/ddc/ddc.lua
+++ b/lua/PluginConfig/ddc/ddc.lua
@@ -6,7 +6,7 @@ local ddc_conf = require('PluginConfig/ddc/helper')
 ----------------
 -- configs
 ----------------
-local ddc_sources = { 'vsnip', 'nvim-lsp', 'file', 'around' }
+local ddc_sources = { 'vsnip', 'lsp', 'file', 'around' }
 local ddc_ui = 'pum'
 local cmdline_sources = {
   [':'] = { 'cmdline-history', 'cmdline', 'around' },
@@ -51,7 +51,7 @@ local source_options = {
     keywordPattern = "\\S*",
     dup = 'keep',
   },
-  ['nvim-lsp'] = {
+  ['lsp'] = {
     mark = 'LSP',
     forceCompletionPattern = '\\.\\w*|::\\w*|->\\w*',
     sorters = { 'sorter_lsp-kind' },
@@ -59,7 +59,7 @@ local source_options = {
   },
 }
 local source_params = {
-  ['nvim-lsp'] = {
+  ['lsp'] = {
     snippetEngine = fn["denops#callback#register"](function(body) fn["vsnip#anonymous"](body) end),
     enableResolveItem = true,
     enableAdditionalTextEdit = true,

--- a/lua/PluginConfig/skkeleton.lua
+++ b/lua/PluginConfig/skkeleton.lua
@@ -75,6 +75,6 @@ api.nvim_create_autocmd('User', {
 api.nvim_create_autocmd('User', {
   pattern = 'skkeleton-disable-pre',
   callback = function()
-    ddc_conf.patch_global('sources', { 'vsnip', 'nvim-lsp', 'file', 'around' })
+    ddc_conf.patch_global('sources', { 'vsnip', 'lsp', 'file', 'around' })
   end,
 })

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -109,7 +109,7 @@ local plugin_list = {
     },
   },
   {
-    "Shougo/ddc-source-nvim-lsp",
+    "Shougo/ddc-source-lsp",
     dependencies = {
       "vim-denops/denops.vim",
       "hrsh7th/vim-vsnip",
@@ -140,7 +140,7 @@ local plugin_list = {
       "Shougo/ddc-line",
       "LumaKernel/ddc-file",
       "uga-rosa/ddc-source-vsnip",
-      "Shougo/ddc-source-nvim-lsp",
+      "Shougo/ddc-source-lsp",
     },
     config = function()
       require("PluginConfig/ddc/ddc")
@@ -166,7 +166,7 @@ local plugin_list = {
     event = 'BufReadPost',
     dependencies = {
       "williamboman/mason.nvim",
-      "Shougo/ddc-source-nvim-lsp",
+      "Shougo/ddc-source-lsp",
       "mhartington/formatter.nvim",
     },
     config = function()


### PR DESCRIPTION
# English
The ddc_source_nvim_lsp has been renamed to ddc_source_lsp, so I have made corresponding adjustments.

# 日本語（Original）
ddc_source_nvim_lspが、ddc_source_lspにリネームされたので、それに対応した。