### PR TITLE
modify - so that folding is enabled in Python code as well

### DIFF
--- a/lua/PluginConfig/nvim-treesitter.lua
+++ b/lua/PluginConfig/nvim-treesitter.lua
@@ -29,5 +29,12 @@ require 'nvim-treesitter.configs'.setup {
   -- },
 }
 
-opt.foldmethod = "expr"
-opt.foldexpr = "nvim_treesitter#foldexpr()"
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = { "*" },
+  callback = function ()
+    if pcall(vim.treesitter.start) then
+      opt.foldmethod="expr"
+      opt.foldexpr = "nvim_treesitter#foldexpr()"
+    end
+  end
+})

--- a/lua/PluginConfig/nvim-treesitter.lua
+++ b/lua/PluginConfig/nvim-treesitter.lua
@@ -31,9 +31,9 @@ require 'nvim-treesitter.configs'.setup {
 
 vim.api.nvim_create_autocmd("FileType", {
   pattern = { "*" },
-  callback = function ()
+  callback = function()
     if pcall(vim.treesitter.start) then
-      opt.foldmethod="expr"
+      opt.foldmethod = "expr"
       opt.foldexpr = "nvim_treesitter#foldexpr()"
     end
   end


### PR DESCRIPTION
# English
## Background
Folding was not enabled in Python code.

## Fix
It worked if I set foldmethod and foldexpr when filetype was set.

# 日本語（Original）
## 背景
Pythonコードでは折り畳みが有効でなかった。

## 修正
filetypeが設定されたときに、foldmethodとfoldexprが設定されるようにすると上手くいった。