### PR TITLE
mini.surroundのキーマップ変更

### DIFF
--- a/lua/PluginConfig/mini-surround.lua
+++ b/lua/PluginConfig/mini-surround.lua
@@ -7,7 +7,7 @@ require('mini.surround').setup({
     delete = 'cd',         -- Delete surrounding
     find = '[c',           -- Find surrounding (to the right)
     find_left = ']c',      -- Find surrounding (to the left)
-    highlight = 'ch',      -- Highlight surrounding
+    -- highlight = 'ch',      -- Highlight surrounding
     replace = 'cs',        -- Replace surrounding
     update_n_linec = 'cn', -- Update `n_lines`
     update_n_lines = '',

--- a/lua/PluginConfig/mini-surround.lua
+++ b/lua/PluginConfig/mini-surround.lua
@@ -5,8 +5,8 @@ require('mini.surround').setup({
   mappings = {
     add = 'cl',            -- Add surrounding in Normal and Visual modes
     delete = 'cd',         -- Delete surrounding
-    find = 'c<',           -- Find surrounding (to the right)
-    find_left = 'c>',      -- Find surrounding (to the left)
+    find = '[c',           -- Find surrounding (to the right)
+    find_left = ']c',      -- Find surrounding (to the left)
     highlight = 'ch',      -- Highlight surrounding
     replace = 'cs',        -- Replace surrounding
     update_n_linec = 'cn', -- Update `n_lines`

--- a/lua/PluginConfig/mini-surround.lua
+++ b/lua/PluginConfig/mini-surround.lua
@@ -3,7 +3,7 @@ require('mini.surround').setup({
   -- Let the first character is 'c', from "Closure".
   -- When it is 's', I felt it was not user-friendly.
   mappings = {
-    add = 'ca',            -- Add surrounding in Normal and Visual modes
+    add = 'cl',            -- Add surrounding in Normal and Visual modes
     delete = 'cd',         -- Delete surrounding
     find = 'c<',           -- Find surrounding (to the right)
     find_left = 'c>',      -- Find surrounding (to the left)


### PR DESCRIPTION
# English
## Background
In situations where the cursor is positioned at the "|" symbol, for example, in a scenario like `(some sent|ence)`, entering `ca(` would activate the mini.surround's enclosure addition mode, and after that, the "(" would be entered. However, with the original key mapping, ca( had the role of deleting the portion enclosed in parentheses, including the parentheses, and entering the input mode afterward. This often led to key mapping errors.

## Modifications
The previous "ca" has been changed to "cl." This change is derived from the first two characters of "closure."

## Remarks
Additionally, unused key mappings have been commented out, and the key mapping for finding parentheses has been changed to a format using square brackets ([]).

# 日本語（Original）
## 背景
|をカーソルの位置として、例えば`(some sent|ence)`というような状況だった場合、`ca(`と入力すると、mini.surroundの囲み追加モードになった後、`(`が入力されるということになっていた。しかしオリジナルのキーマップなら、`ca(`は()で囲まれている部分を、括弧を含めて削除した後、入力モードに入るという役割を持っているので、よくキーマップの誤入力が起きていた。

## 修正
今までcaだったものを、clに変更した。これはclosureの最初2文字から取っている。

## 備考
ついでに、使わないキーマップをコメントアウトして、括弧を見つけるためのキーマップを[]を使った形式に変更した。