### PR TITLE
modify - keymap to highlight surrounding

### DIFF
--- a/lua/PluginConfig/mini-surround.lua
+++ b/lua/PluginConfig/mini-surround.lua
@@ -7,7 +7,7 @@ require('mini.surround').setup({
     delete = 'cd',         -- Delete surrounding
     find = '[c',           -- Find surrounding (to the right)
     find_left = ']c',      -- Find surrounding (to the left)
-    -- highlight = 'ch',      -- Highlight surrounding
+    highlight = '',        -- Highlight surrounding
     replace = 'cs',        -- Replace surrounding
     update_n_linec = 'cn', -- Update `n_lines`
     update_n_lines = '',


### PR DESCRIPTION
mini.surroundにはデフォルトでキーマップが設定されていたようで、sを押すと、しばらく次のキー入力を待ってから、何も入力しなければ一文字削除して入力モードに入るという動作になっていた。この待ち時間が嫌だった。