### PR TITLE
modify - parameter names and definitions for skkeleton#config

### DIFF
--- a/lua/PluginConfig/skkeleton.lua
+++ b/lua/PluginConfig/skkeleton.lua
@@ -12,11 +12,11 @@ local my_dictionary_path = util.join_paths(data_path, 'SKK-JISYO.MY')
 fn['skkeleton#config'] {
   -- debug = true,
   eggLikeNewline = true,
-  globalJisyo = dictionary_source_path,
+  globalDictionaries = {dictionary_source_path},
   markerHenkan = '<>',
   markerHenkanSelect = '>>',
   registerConvertResult = true,
-  userJisyo = my_dictionary_path,
+  userDictionary = my_dictionary_path,
 }
 
 fn['skkeleton#register_kanatable'](


### PR DESCRIPTION
# Fix
There have been breaking changes in skkeleton. Specifically, globalJisyo and userJisyo have been removed, with the latter being replaced by userDictionary.

The configuration file has also been adjusted accordingly.

# 修正（Original）
skkeletonで破壊的変更があった。具体的には、globalJisyoとuseJisyoが削除されて、後者はuserDictionaryに変更された。

設定ファイルもそれに対応した。