### PR TITLE
bugfix - skkeleton does not run correctly, if this config is used in container

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -170,7 +170,7 @@ local plugin_list = {
       "vim-denops/denops.vim",
       "Shougo/ddc.vim",
     },
-    event = 'VeryLazy',
+    event = 'VimEnter',
     config = function()
       require("PluginConfig/skkeleton")
     end,


### PR DESCRIPTION
# 背景
Docker上でNeovimを動かして、その設定ファイルとしてこのリポジトリのものを使うと、skkeletonを利用できなかった。

# 解決方法
skkeletonの読み込まれるタイミングをVimEnterに変更した。