### PR TITLE
add - matchpairs option

### DIFF
--- a/lua/Options.lua
+++ b/lua/Options.lua
@@ -46,6 +46,7 @@ opt.updatetime = 200 -- time to highlight
 opt.mouse = "" -- disable mouse
 opt.fileformats = { "unix", "dos", "mac" }
 opt.cmdheight=0
+opt.matchpairs = "（:）,「:」,『:』,【:】,［:］,＜:＞"
 vg.loaded_netrw = false -- disable netrw
 vg.loaded_netrwPlugin = false -- disable netrw plugins
 


### PR DESCRIPTION
# English
## Background
It was inconvenient that jumping or highlighting with '%' did not work for full-width parentheses, especially when writing Markdown.

## Modifiation
It seems that defining parentheses pairs in opt.matchpairs resolves this issue, so I addressed it in that manner.

# 日本語（Original）
## 背景
全角の括弧に対しては、'%'でのジャンプやハイライトができなかった。Markdownを書くときなどに不便だった。

## 修正
どうやらこれは、opt.matchpairsに括弧のペアを定義すると解決できるようだったので、そうして解決した。