### PR TITLE
treak - I forgot to set opt.matchpairs its default value

### DIFF
--- a/lua/Options.lua
+++ b/lua/Options.lua
@@ -46,7 +46,7 @@ opt.updatetime = 200 -- time to highlight
 opt.mouse = "" -- disable mouse
 opt.fileformats = { "unix", "dos", "mac" }
 opt.cmdheight=0
-opt.matchpairs = "（:）,「:」,『:』,【:】,［:］,＜:＞"
+opt.matchpairs = opt.matchpairs + "（:）,「:」,『:』,【:】,［:］,＜:＞"
 vg.loaded_netrw = false -- disable netrw
 vg.loaded_netrwPlugin = false -- disable netrw plugins
 


### PR DESCRIPTION
# English
## Background
Before this change, the default value was missing from the opt.matchpairs setting. As a result, even when the cursor was over a half-width parenthesis, it couldn't jump with '%' or get highlighted.

# 日本語（Original）
## 背景
この変更の前は、opt.matchpairsの設定からデフォルト値が消えてしまっていた。そのため、カーソルが半角括弧上にあっても、'%'でジャンプできなかったり、ハイライトされなかったりしていた。