### PR TITLE
Feat/add GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: JohnnyMorganz/stylua-action@v4
+        id: stylua
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,10 @@ jobs:
     name: check-format
     steps:
       - uses: actions/checkout@v4
+
+      - name: make output file
+        run: echo "PR_LOG=$(mktemp)" >> $GITHUB_ENV
+
       - uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,4 +19,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
-          args: --check . -g '*.lua'
+          args: --check . -g '*.lua' 2> >(tee "$PR_LOG")
+      - name: isFailed
+        run: test ! -s "$PR_LOG"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
           args: --check . -g '*.lua'
-        shell: bash -e {0} > $PR_LOG 2>&1
+        run: stylua --check . -g '*.lua' > $PR_LOG 2> 1
 
       - run: |
           if [[ ${{ steps.stylua.outputs.exit_code }} != 0 ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,9 @@ jobs:
     name: check-format
     steps:
       - uses: actions/checkout@v4
-
       - uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
           args: --check . -g '*.lua'
-
-      - run: stylua --check . -g '*.lua'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,7 @@ jobs:
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
 
-      - run:
-        run: stylua --check . -g '*.lua'
+      - run: stylua --check . -g '*.lua'
         shell: bash -c "bash -e {0} 2> >(tee "$PR_LOG" >&2)"
 
       - name: isFailed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
 
       - name: make output file
         run: echo "PR_LOG=$(mktemp)" >> $GITHUB_ENV
+          shell: bash -c "bash -e {0} 2> >(tee "$PR_LOG" >&2)"
 
       - uses: JohnnyMorganz/stylua-action@v4
         with:
@@ -20,7 +21,6 @@ jobs:
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
           args: --check . -g '*.lua'
-          shell: bash -c "bash -e {0} 2> >(tee  "$PR_LOG" >&2)"
       - name: isFailed
         run: test ! -s "$PR_LOG"
           cat $PR_LOG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
-          args: --check . -g '*.lua' 2> >(tee "$PR_LOG")
+          args: --check . -g '*.lua'
+          shell: bash -c "bash -e {0} 2> >(tee  "$PR_LOG" >&2)"
       - name: isFailed
         run: test ! -s "$PR_LOG"
           cat $PR_LOG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ jobs:
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
           args: --check . -g '*.lua'
-        run: stylua --check . -g '*.lua' > $PR_LOG 2> 1
 
       - run: |
           if [[ ${{ steps.stylua.outputs.exit_code }} != 0 ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,4 +18,8 @@ jobs:
           # CLI arguments
           args: --check . -g '*.lua'
 
-      - run: stylua --check . -g '*.lua'
+      - run: |
+          if [[ ${{ steps.stylua.outputs.exit_code }} != 0 ]]; then
+            echo "There were formatting issues detected."
+            exit 1
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: make output file
-        run: echo "PR_LOG=$(mktemp)" >> $GITHUB_ENV
-
       - uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -22,8 +19,3 @@ jobs:
           args: --check . -g '*.lua'
 
       - run: stylua --check . -g '*.lua'
-
-      - name: isFailed
-        run: | 
-          test ! -s "$PR_LOG"
-          cat $PR_LOG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     name: check-format
     steps:
+      - name: create log file
+        run: echo "PR_LOG=$(mktemp)" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
 
       - uses: JohnnyMorganz/stylua-action@v4
@@ -18,6 +21,7 @@ jobs:
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
           args: --check . -g '*.lua'
+        shell: bash -e {0} > $PR_LOG 2>&1
 
       - run: |
           if [[ ${{ steps.stylua.outputs.exit_code }} != 0 ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
           args: --check . -g '*.lua'
+
       - name: isFailed
-        run: test ! -s "$PR_LOG"
+        run: | 
+          test ! -s "$PR_LOG"
           cat $PR_LOG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
+          args: --check . -g '*.lua'
 
       - run: stylua --check . -g '*.lua'
         shell: bash -c "bash -e {0} 2> >(tee "$PR_LOG" >&2)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,6 @@ jobs:
           args: --check . -g '*.lua'
 
       - run: stylua --check . -g '*.lua'
-        shell: bash -c "bash -e {0} 2> >(tee "$PR_LOG" >&2)"
 
       - name: isFailed
         run: | 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,16 @@ jobs:
 
       - name: make output file
         run: echo "PR_LOG=$(mktemp)" >> $GITHUB_ENV
-        shell: bash -c "bash -e {0} 2> >(tee "$PR_LOG" >&2)"
 
       - uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
           # CLI arguments
-          args: --check . -g '*.lua'
+
+      - run:
+        run: stylua --check . -g '*.lua'
+        shell: bash -c "bash -e {0} 2> >(tee "$PR_LOG" >&2)"
 
       - name: isFailed
         run: | 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           args: --check . -g '*.lua'
 
       - run: |
-          echo "${{steps.stylua.outputs}}"
+          echo "${{steps.stylua.outputs.result}}"
           if [[ ${{ steps.stylua.outputs.exit_code }} != 0 ]]; then
             echo "There were formatting issues detected."
             exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: make output file
         run: echo "PR_LOG=$(mktemp)" >> $GITHUB_ENV
-          shell: bash -c "bash -e {0} 2> >(tee "$PR_LOG" >&2)"
+        shell: bash -c "bash -e {0} 2> >(tee "$PR_LOG" >&2)"
 
       - uses: JohnnyMorganz/stylua-action@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
           args: --check . -g '*.lua'
 
       - run: |
+          echo ${{steps.stylua.outputs.exit_code}}
           if [[ ${{ steps.stylua.outputs.exit_code }} != 0 ]]; then
             echo "There were formatting issues detected."
             exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,4 @@ jobs:
           args: --check . -g '*.lua' 2> >(tee "$PR_LOG")
       - name: isFailed
         run: test ! -s "$PR_LOG"
+          cat $PR_LOG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           args: --check . -g '*.lua'
 
       - run: |
-          echo ${{steps.stylua.outputs.exit_code}}
+          echo "${{steps.stylua.outputs}}"
           if [[ ${{ steps.stylua.outputs.exit_code }} != 0 ]]; then
             echo "There were formatting issues detected."
             exit 1

--- a/lua/Options.lua
+++ b/lua/Options.lua
@@ -1,6 +1,6 @@
 ---- HELPERS ----
 local api = vim.api
-local fn = vim.fn
+local fn    = vim.fn
 local opt = vim.opt -- to set options
 local cmd = vim.cmd -- to execute Vim commands e.g. cmd('pwd')
 local vg = vim.g


### PR DESCRIPTION
# English
After running Stylua, if there is at least one fixable location by Stylua, I want to mark the GitHub Actions result as failed. However, even if there are fixable locations, the [StyLua GitHub Action](https://github.com/marketplace/actions/stylua) does not fail. Therefore, until now, we have been marking it as failed by re-running Stylua and outputting the result.

However, this felt inefficient in terms of time, so ideally, I would like to run Stylua only once.

# 日本語（Original）
## 背景
Styluaを実行した後、Styluaにより修正可能な個所が1か所でもあれば、GitHub Actionsの結果を失敗としたい。しかし、[StyLua GitHub Action](https://github.com/marketplace/actions/stylua)では修正可能な個所があったとしても、失敗とならない。そのため、今までは再度Styluaを実行することで、その結果を出力することで失敗にしていた。

しかし、これは時間的にも非効率な気がしていたので、できればStyluaの実行は1回にしておきたい。