### PR TITLE
Fix/keymap/jump plugins

### DIFF
--- a/lua/PluginConfig/hop.lua
+++ b/lua/PluginConfig/hop.lua
@@ -32,7 +32,7 @@ for k, v in pairs({
   ["[hop]lj"] = function()
     hop.hint_lines({ direction = hint.HintDirection.AFTER_CURSOR })
   end,
-  ["[hop]/"] = hop.hint_patterns,
+  -- ["[hop]/"] = hop.hint_patterns,
   ["[hop]r"] = hop.hint_char1,
   ["[hop]h"] = hop.hint_char2,
   ["f"] = function()

--- a/lua/PluginConfig/hop.lua
+++ b/lua/PluginConfig/hop.lua
@@ -8,8 +8,8 @@ hop.setup({ keys = "etovxqpdygfblzhckisuran" })
 -- place this in one of your configuration file(s)
 api.nvim_set_keymap("n", "[hop]", "<Nop>", { noremap = true, silent = true })
 api.nvim_set_keymap("v", "[hop]", "<Nop>", { noremap = true, silent = true })
-api.nvim_set_keymap("n", "<Space><Space>", "[hop]", {})
-api.nvim_set_keymap("v", "<Space><Space>", "[hop]", {})
+api.nvim_set_keymap("n", "<Space>o", "[hop]", {})
+api.nvim_set_keymap("v", "<Space>o", "[hop]", {})
 
 -- Normal Mode
 local hint = require("hop.hint")

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -60,7 +60,7 @@ local plugin_list = {
     dependencies = { "vim-denops/denops.vim", "lambdalisue/kensaku.vim" },
     event = "VeryLazy",
     config = function()
-      vim.keymap.set("n", "<Space><Space>m", "<cmd>FuzzyMotion<CR>")
+      vim.keymap.set("n", "<Space>/", "<cmd>FuzzyMotion<CR>")
       vim.g.fuzzy_motion_matchers = { "kensaku", "fzf" }
     end,
   },


### PR DESCRIPTION
# Background
When trying to press the Space key twice for jumping, I often ended up pressing it only once or pressing it three times by mistake. Therefore, I wanted to change the combination to use the Space key with another key. 

# 
I assigned "o" as the key for the telescope functionality, creating a combination of "<Space>o + <action key>". Similarly, I assigned "/" as the key for fuzzy motion.