### PR TITLE
solve the ddc and skkeleton warning 'skkeleton ddc filter is deprecated. Because filtering by source itself.'

### DIFF
--- a/lua/PluginConfig/skkeleton.lua
+++ b/lua/PluginConfig/skkeleton.lua
@@ -50,7 +50,7 @@ util.add_keymaps(skkeleton_keymap)
 local source_options = {
   ["skkeleton"] = {
     mark = "SKK",
-    matchers = { "skkeleton" },
+    matchers = {},
     sorters = {},
     minAutoCompleteLength = 2,
     isVolatile = true,


### PR DESCRIPTION
I fixed this issue because the message "skkeleton ddc filter is deprecated. Because filtering by source itself." was displayed every time a key was pressed while using SKK input.