### PR TITLE
fix the issue if filename has special characters, then git log occurs error

### DIFF
--- a/lua/PluginConfig/telescope.lua
+++ b/lua/PluginConfig/telescope.lua
@@ -12,7 +12,7 @@ local function run_selection(prompt_bufnr, map)
   actions.select_default:replace(function()
     actions.close(prompt_bufnr)
     local selection = action_state.get_selected_entry()
-    vim.cmd([[!git log ]] .. selection[1])
+    vim.cmd([[!git log "]] .. selection[1] .. [["]])
   end)
   return true
 end


### PR DESCRIPTION
I fixed an issue where special characters like '(' or ')' in file names caused errors in git log. This issue commonly arises when using frameworks like Next.js.