### PR TITLE
remove vim-markdown plugin

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -226,10 +226,6 @@ local plugin_list = {
   -- for markdown
   ------------------
   {
-    "preservim/vim-markdown",
-    event = "VeryLazy",
-  },
-  {
     "tyru/open-browser.vim",
   },
   {


### PR DESCRIPTION
Originally I added this plugin for markdown highlighting and folding, but it was redundant with nvim-treesitter, so I removed it.