### PR TITLE
add key actions to move tabs

### DIFF
--- a/lua/KeyMappings.lua
+++ b/lua/KeyMappings.lua
@@ -32,6 +32,8 @@ for k, v in pairs({
   ["[b"] = ":bp<CR>",
   ["]b"] = ":bn<CR>",
   ["*"] = ":%s/\\v",
+  ["]t"] = ":tabnext<CR>",
+  ["[t"] = ":tabprevious<CR>",
   -- ["<Space>b"] = ":%!xxd<CR>",
   ["<Space><CR>"] = ":.!bash<CR>",
   ["<C-p>"] = '"*p',


### PR DESCRIPTION
Added key actions to move tabs, as tabs sometimes open even if they aren't actively used, such as when running `checkhealth`.