### PR TITLE
fix: update nvim-treesitter configuration for Neovim 0.12 compatibility

### DIFF
--- a/lua/PluginConfig/nvim-treesitter.lua
+++ b/lua/PluginConfig/nvim-treesitter.lua
@@ -1,19 +1,18 @@
-local api = vim.api
-local bo = vim.bo
-local fn = vim.fn
-local ts = vim.treesitter
-local wo = vim.wo
-
-require("nvim-treesitter").setup({
-  install_dir = fn.stdpath("data") .. "/treesitter-parser",
-})
-
-api.nvim_create_autocmd({ "FileType" }, {
-  pattern = { "tsx", "typescript", "typescriptreact", "python", "markdown", "cpp", "cmake", "lua", "bash" },
-  callback = function()
-    ts.start()
-    wo.foldmethod = "expr"
-    wo.foldexpr = "v:lua.vim.treesitter.foldexpr()"
-    bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
-  end,
-})
+local ensure_installed = {
+  "tsx",
+  "typescript",
+  "python",
+  "markdown",
+  "cpp",
+  "cmake",
+  "lua",
+  "bash",
+  "dockerfile",
+}
+local already_installed = require("nvim-treesitter.config").get_installed()
+local to_install = vim.tbl_filter(function(p)
+  return not vim.tbl_contains(already_installed, p)
+end, ensure_installed)
+if #to_install > 0 then
+  require("nvim-treesitter").install(to_install)
+end

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -14,10 +14,7 @@ local plugin_list = {
   {
     "nvim-treesitter/nvim-treesitter",
     branch = "main",
-    event = "BufReadPost",
-    build = ":TSUpdateSync",
-    dependencies = { "windwp/nvim-ts-autotag" },
-    config = function()
+    init = function()
       require("PluginConfig/nvim-treesitter")
     end,
   },


### PR DESCRIPTION
nvim-treesitter is archived on GitHub, but since there is currently no alternative, I will modify the settings to work with Neovim 0.12 and continue using it for the time being.